### PR TITLE
Closes #11 Chore: Formally deprecate Python 3.6 support in bio-informatic core

### DIFF
--- a/__wip7/ReverseSinglyLinkedList.js
+++ b/__wip7/ReverseSinglyLinkedList.js
@@ -1,0 +1,16 @@
+/** A LinkedList based solution to reverse a number
+Problem Statement: Given a number such that each of its digit is stored in a singly linked list. Reverse the linked list and return the head of the linked list Link for the Problem: https://leetcode.com/problems/reverse-linked-list/ */
+class ReverseSinglyLinkedList {
+  solution(head) {
+    let prev = null
+    let next = null
+    while (head) {
+      next = head.next
+      head.next = prev
+      prev = head
+      head = next
+    }
+    return prev
+  }
+}
+export { ReverseSinglyLinkedList }

--- a/__wip7/VigenereCipher.test.js
+++ b/__wip7/VigenereCipher.test.js
@@ -1,0 +1,13 @@
+import { encrypt, decrypt } from '../VigenereCipher'
+
+test('Hello world! === decrypt(encrypt(Hello world!))', () => {
+  const word = 'Hello world!'
+  const result = decrypt(encrypt(word, 'code'), 'code')
+  expect(result).toMatch(word)
+})
+
+test('The Algorithms === decrypt(encrypt(The Algorithms))', () => {
+  const word = 'The Algorithms'
+  const result = decrypt(encrypt(word, 'code'), 'code')
+  expect(result).toMatch(word)
+})


### PR DESCRIPTION
11 This edge case affecting only Python 3.7 will not be addressed since that version reached end-of-life. Our resources are better spent supporting current and future Python versions that the majority of our user base employs.